### PR TITLE
feat: updated SDK to use `@corti/sdk` for socket connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "@corti/dictation-web",
-  "version": "0.1.6",
+  "version": "0.1.16-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@corti/dictation-web",
-      "version": "0.1.6",
+      "version": "0.1.16-rc",
+      "license": "MIT",
       "dependencies": {
+        "@corti/sdk": "^0.1.3-alpha",
         "lit": "^3.1.4"
       },
       "devDependencies": {
@@ -37,6 +39,31 @@
         "storybook": "^7.6.20",
         "tslib": "^2.6.3",
         "typescript": "^5.5.3"
+      }
+    },
+    "../corti-sdk-typescript": {
+      "name": "@corti/sdk",
+      "version": "0.1.3-alpha",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.16.0"
+      },
+      "devDependencies": {
+        "@jest/globals": "^29.7.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^18.19.70",
+        "@types/ws": "^8.5.10",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "msw": "^2.8.4",
+        "prettier": "^3.4.2",
+        "ts-jest": "^29.3.4",
+        "ts-loader": "^9.5.1",
+        "typescript": "~5.7.2",
+        "webpack": "^5.97.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1853,6 +1880,10 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@corti/sdk": {
+      "resolved": "../corti-sdk-typescript",
+      "link": true
     },
     "node_modules/@custom-elements-manifest/analyzer": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@corti/dictation-web",
   "description": "Web component for Corti Dictation",
   "author": "Corti ApS",
-  "version": "0.1.15",
+  "version": "0.1.16-rc",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,6 +49,7 @@
     "storybook:build": "tsc && npm run analyze -- --exclude dist && storybook build"
   },
   "dependencies": {
+    "@corti/sdk": "^0.1.3-alpha",
     "lit": "^3.1.4"
   },
   "devDependencies": {

--- a/src/CortiDictation.ts
+++ b/src/CortiDictation.ts
@@ -1,3 +1,5 @@
+import { Corti } from '@corti/sdk';
+
 // corti-dictation.ts
 import { html, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -9,7 +11,7 @@ import ThemeStyles from './styles/theme.js';
 import ButtonStyles from './styles/buttons.js';
 import ComponentStyles from './styles/ComponentStyles.js';
 
-import type { DictationConfig, RecordingState, ServerConfig } from './types.js';
+import type { RecordingState, ServerConfig } from './types.js';
 import { DEFAULT_DICTATION_CONFIG, LANGUAGES_SUPPORTED } from './constants.js';
 import CalloutStyles from './styles/callout.js';
 import { decodeToken } from './utils.js';
@@ -18,10 +20,10 @@ export class CortiDictation extends LitElement {
   static styles = [ButtonStyles, ThemeStyles, ComponentStyles, CalloutStyles];
 
   @property({ type: Object })
-  dictationConfig: DictationConfig = DEFAULT_DICTATION_CONFIG;
+  dictationConfig: Corti.TranscribeConfig = DEFAULT_DICTATION_CONFIG;
 
   @property({ type: Array })
-  languagesSupported: string[] = LANGUAGES_SUPPORTED;
+  languagesSupported: Corti.TranscribeSupportedLanguage[] = LANGUAGES_SUPPORTED;
 
   @property({ type: Boolean })
   debug_displayAudio: boolean = false;
@@ -95,8 +97,6 @@ export class CortiDictation extends LitElement {
       });
     });
   }
-
-
 
   public toggleRecording() {
     this._toggleRecording();

--- a/src/RecorderManager.ts
+++ b/src/RecorderManager.ts
@@ -1,7 +1,9 @@
+import { Corti } from '@corti/sdk';
+
 import { getAudioDevices, getMediaStream } from './utils.js';
 import { AudioService } from './audioService.js';
 import { DictationService } from './DictationService.js';
-import type { DictationConfig, RecordingState, ServerConfig } from './types.js';
+import type { RecordingState, ServerConfig } from './types.js';
 
 export class RecorderManager extends EventTarget {
   public devices: MediaDeviceInfo[] = [];
@@ -60,7 +62,7 @@ export class RecorderManager extends EventTarget {
   }
 
   async startRecording(params: {
-    dictationConfig: DictationConfig;
+    dictationConfig: Corti.TranscribeConfig;
     serverConfig: ServerConfig;
     debug_displayAudio?: boolean;
   }): Promise<void> {

--- a/src/components/settings-menu.ts
+++ b/src/components/settings-menu.ts
@@ -150,7 +150,8 @@ export class SettingsMenu extends LitElement {
                   device => html`
                     <option
                       value=${device.deviceId}
-                      ?selected=${this.selectedDevice?.deviceId === device.deviceId}
+                      ?selected=${this.selectedDevice?.deviceId ===
+                      device.deviceId}
                     >
                       ${device.label || 'Unknown Device'}
                     </option>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,14 @@
-import { DictationConfig } from './types.js';
+import { Corti } from '@corti/sdk';
 
-export const LANGUAGES_SUPPORTED = ['en', 'en-GB', 'da', 'de', 'fr', 'sv' ];
-export const DEFAULT_DICTATION_CONFIG: DictationConfig = {
+export const LANGUAGES_SUPPORTED: Corti.TranscribeSupportedLanguage[] = [
+  'en',
+  'en-GB',
+  'da',
+  'de',
+  'fr',
+  'sv',
+];
+export const DEFAULT_DICTATION_CONFIG: Corti.TranscribeConfig = {
   primaryLanguage: 'en',
   interimResults: true,
   spokenPunctuation: true,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,7 +4,10 @@ const ThemeStyles = css`
   :host {
     color-scheme: light dark;
     /* Component Defaults */
-    --component-font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto, noto, helvetica, arial, sans-serif;
+    --component-font-family:
+      -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,
+      helvetica neue, Cantarell, Ubuntu, roboto, noto, helvetica, arial,
+      sans-serif;
     --component-text-color: light-dark(#333, #eee);
 
     /* Card Defaults */

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,29 +4,6 @@ export type RecordingState =
   | 'stopping'
   | 'stopped';
 
-interface CommandVariable {
-  key: string;
-  type: 'enum' | 'string';
-  enum?: string[];
-}
-
-export interface Command {
-  id: string;
-  phrases: string[];
-  variables?: CommandVariable[];
-}
-
-export interface DictationConfig {
-  primaryLanguage: string;
-  interimResults: boolean;
-  spokenPunctuation: boolean;
-  automaticPunctuation: boolean;
-  model?: string;
-  commands?: Command[];
-}
-
-export type PartialDictationConfig = Partial<DictationConfig>;
-
 export interface ServerConfig {
   environment: string;
   tenant: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,3 +185,11 @@ export async function getMediaStream(deviceId?: string): Promise<MediaStream> {
 
   return await navigator.mediaDevices.getUserMedia(constraints);
 }
+
+export function getErrorMessage(event: Error) {
+  try {
+    return JSON.parse(event.message);
+  } catch {
+    return event?.message || event;
+  }
+}


### PR DESCRIPTION
**Note on reconnects**:
It was expected that reconnects would occur when using the Corti SDK. However, I wasn’t able to reproduce this behavior. Most of the errors I can generate manually result in the socket being closed with an error, which disables automatic reconnections by default. That said, another related bug appears to be fixed with this change.

**Note on testing**:
In addition to the integration at https://github.com/corticph/corti-api-console/pull/157 , I also ran some manual tests to verify that we’re still firing the same events as before. This testing actually led to the need to [update Corti SDK](https://github.com/corticph/corti-sdk-typescript/releases/tag/v0.1.3-alpha).
We’re now missing one specific error (related to closing the WebSocket when it’s already closed) and its consequences — but everything else appears unchanged.
That said, an extra round of testing would be much appreciated 🙏

The package is currently released as an  ["rc" version](https://www.npmjs.com/package/@corti/dictation-web/v/0.1.16-rc) for testing purposes. 

### Changes

1. **Updated types to use definitions from `@corti/sdk`**

1. **Updated SDK to use `@corti/sdk` for socket connection**

1. **Fixed unexpected stream closure when a second attempt is made before the first socket closes**
This bug is hard to reproduce in production, as it takes longer to send the ended message that triggers the issue.
The example video comes from the dev environment.

**Before**

https://github.com/user-attachments/assets/c6523297-8d78-4c61-bbb3-c81f1f45c0ac

**After**

https://github.com/user-attachments/assets/4a271e13-b528-460b-b9fa-f0509a71dba8


