### PR TITLE
fix(devices): populate audio input list in Firefox after page reload

### DIFF
--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -1,14 +1,15 @@
 /**
- * Requests access to the microphone.
+ * Primes the document with an active microphone stream.
  *
  * Opens (and immediately stops) a media stream so the document holds an
- * active mic permission for this session. Throws early if the user has
- * already denied permission.
+ * active mic permission for this session. In Firefox this is what makes
+ * real deviceIds and labels appear in subsequent enumerateDevices() calls.
+ * Throws early if the user has already denied permission.
  *
- * @returns A promise that resolves when the permission request is complete.
+ * @returns A promise that resolves once the stream has been opened and stopped.
  * @throws Error if microphone access is denied or unavailable.
  */
-export async function requestMicAccess(): Promise<void> {
+export async function primeMicStream(): Promise<void> {
   if (navigator.permissions) {
     const permissionStatus = await navigator.permissions.query({
       name: "microphone" as PermissionName,
@@ -51,7 +52,7 @@ export async function getAudioDevices(): Promise<{
   let audioDevices = await listAudioInputs();
 
   if (needsMicPriming(audioDevices)) {
-    await requestMicAccess();
+    await primeMicStream();
     audioDevices = await listAudioInputs();
   }
 
@@ -68,7 +69,7 @@ async function listAudioInputs(): Promise<MediaDeviceInfo[]> {
 
 function needsMicPriming(audioInputs: MediaDeviceInfo[]): boolean {
   if (audioInputs.length === 0) {
-    return false;
+    return false; // no mic hardware — don't trigger a permission prompt
   }
   return audioInputs.some((d) => d.deviceId === "" || d.label === "");
 }

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -1,46 +1,39 @@
 /**
  * Requests access to the microphone.
  *
- * This function checks if the microphone permission is in "prompt" state, then requests
- * access and stops any active tracks immediately.
+ * Opens (and immediately stops) a media stream so the document holds an
+ * active mic permission for this session. Throws early if the user has
+ * already denied permission.
  *
  * @returns A promise that resolves when the permission request is complete.
  * @throws Error if microphone access is denied or unavailable.
  */
 export async function requestMicAccess(): Promise<void> {
-  if (!navigator.permissions) {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
-    stream.getTracks().forEach((track) => {
-      track.stop();
+  if (navigator.permissions) {
+    const permissionStatus = await navigator.permissions.query({
+      name: "microphone" as PermissionName,
     });
 
-    return;
+    if (permissionStatus.state === "denied") {
+      throw new Error("Microphone permission is denied");
+    }
   }
 
-  const permissionStatus = await navigator.permissions.query({
-    name: "microphone" as PermissionName,
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+  stream.getTracks().forEach((track) => {
+    track.stop();
   });
-
-  if (permissionStatus.state === "denied") {
-    throw new Error("Microphone permission is denied");
-  }
-
-  if (permissionStatus.state === "prompt") {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
-    stream.getTracks().forEach((track) => {
-      track.stop();
-    });
-  }
 }
 
 /**
  * Retrieves available audio input devices.
  *
- * This function uses the mediaDevices API to enumerate devices and filters out those
- * which are audio inputs. In some browsers, you may need to request user media before
- * device labels are populated.
+ * Enumerates devices first; if the result looks like Firefox's pre-permission
+ * placeholder (an entry with empty deviceId/label even though the Permissions
+ * API reports access), primes the document with getUserMedia and re-enumerates.
+ * Browsers that already return populated entries (Chrome, Safari) skip the
+ * priming call entirely.
  *
  * @returns A promise that resolves with an object containing:
  *  - `devices`: an array of MediaDeviceInfo objects for audio inputs.
@@ -55,11 +48,27 @@ export async function getAudioDevices(): Promise<{
     throw new Error("MediaDevices API is not available");
   }
 
-  await requestMicAccess();
+  let audioDevices = await listAudioInputs();
 
+  if (needsMicPriming(audioDevices)) {
+    await requestMicAccess();
+    audioDevices = await listAudioInputs();
+  }
+
+  return {
+    defaultDevice: audioDevices[0],
+    devices: audioDevices,
+  };
+}
+
+async function listAudioInputs(): Promise<MediaDeviceInfo[]> {
   const devices = await navigator.mediaDevices.enumerateDevices();
-  const audioDevices = devices.filter((device) => device.kind === "audioinput");
-  const defaultDevice = audioDevices.length > 0 ? audioDevices[0] : undefined;
+  return devices.filter((device) => device.kind === "audioinput");
+}
 
-  return { defaultDevice, devices: audioDevices };
+function needsMicPriming(audioInputs: MediaDeviceInfo[]): boolean {
+  if (audioInputs.length === 0) {
+    return false;
+  }
+  return audioInputs.some((d) => d.deviceId === "" || d.label === "");
 }

--- a/test/devices.test.ts
+++ b/test/devices.test.ts
@@ -45,93 +45,111 @@ const NON_AUDIO_DEVICES: MediaDeviceInfo[] = [
   } as MediaDeviceInfo,
 ];
 
-let originalMediaDevices: PropertyDescriptor | undefined;
-let originalPermissions: PropertyDescriptor | undefined;
-
-function installFakeNavigator(opts: {
+interface InstallOpts {
   permissionState?: PermissionState | "unavailable";
   enumerateResults: MediaDeviceInfo[][];
   getUserMediaRejection?: Error;
-}): { fakeMediaDevices: FakeMediaDevices; trackStop: sinon.SinonSpy } {
-  const trackStop = sinon.spy();
-  const fakeStream = {
-    getTracks: () => [{ stop: trackStop }],
-  } as unknown as MediaStream;
-
-  const enumerateStub = sinon.stub();
-  opts.enumerateResults.forEach((result, i) => {
-    enumerateStub.onCall(i).resolves(result);
-  });
-  const lastResult =
-    opts.enumerateResults[opts.enumerateResults.length - 1] ?? [];
-  enumerateStub.resolves(lastResult);
-
-  const getUserMediaStub = sinon.stub();
-  if (opts.getUserMediaRejection) {
-    getUserMediaStub.rejects(opts.getUserMediaRejection);
-  } else {
-    getUserMediaStub.resolves(fakeStream);
-  }
-
-  const fakeMediaDevices: FakeMediaDevices = {
-    addEventListener: () => {},
-    enumerateDevices: enumerateStub,
-    getUserMedia: getUserMediaStub,
-    removeEventListener: () => {},
-  };
-
-  originalMediaDevices = Object.getOwnPropertyDescriptor(
-    navigator,
-    "mediaDevices",
-  );
-  Object.defineProperty(navigator, "mediaDevices", {
-    configurable: true,
-    value: fakeMediaDevices,
-  });
-
-  originalPermissions = Object.getOwnPropertyDescriptor(
-    navigator,
-    "permissions",
-  );
-  if (opts.permissionState === "unavailable") {
-    Object.defineProperty(navigator, "permissions", {
-      configurable: true,
-      value: undefined,
-    });
-  } else {
-    const fakePermissions: FakePermissions = {
-      query: sinon
-        .stub()
-        .resolves({ state: opts.permissionState ?? "granted" }),
-    };
-    Object.defineProperty(navigator, "permissions", {
-      configurable: true,
-      value: fakePermissions,
-    });
-  }
-
-  return { fakeMediaDevices, trackStop };
 }
 
-function restoreNavigator(): void {
-  if (originalMediaDevices) {
-    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
-    originalMediaDevices = undefined;
-  }
-  if (originalPermissions) {
-    Object.defineProperty(navigator, "permissions", originalPermissions);
-    originalPermissions = undefined;
-  }
+interface InstallResult {
+  fakeMediaDevices: FakeMediaDevices;
+  trackStop: sinon.SinonSpy;
+}
+
+function createNavigatorSandbox(): {
+  install: (opts: InstallOpts) => InstallResult;
+  restore: () => void;
+} {
+  let activeRestore: (() => void) | null = null;
+
+  const install = (opts: InstallOpts): InstallResult => {
+    const trackStop = sinon.spy();
+    const fakeStream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+
+    const enumerateStub = sinon.stub();
+    opts.enumerateResults.forEach((result, i) => {
+      enumerateStub.onCall(i).resolves(result);
+    });
+    const lastResult =
+      opts.enumerateResults[opts.enumerateResults.length - 1] ?? [];
+    enumerateStub.resolves(lastResult);
+
+    const getUserMediaStub = sinon.stub();
+    if (opts.getUserMediaRejection) {
+      getUserMediaStub.rejects(opts.getUserMediaRejection);
+    } else {
+      getUserMediaStub.resolves(fakeStream);
+    }
+
+    const fakeMediaDevices: FakeMediaDevices = {
+      addEventListener: () => {},
+      enumerateDevices: enumerateStub,
+      getUserMedia: getUserMediaStub,
+      removeEventListener: () => {},
+    };
+
+    const originalMediaDevices = Object.getOwnPropertyDescriptor(
+      navigator,
+      "mediaDevices",
+    );
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: fakeMediaDevices,
+    });
+
+    const originalPermissions = Object.getOwnPropertyDescriptor(
+      navigator,
+      "permissions",
+    );
+    if (opts.permissionState === "unavailable") {
+      Object.defineProperty(navigator, "permissions", {
+        configurable: true,
+        value: undefined,
+      });
+    } else {
+      const fakePermissions: FakePermissions = {
+        query: sinon
+          .stub()
+          .resolves({ state: opts.permissionState ?? "granted" }),
+      };
+      Object.defineProperty(navigator, "permissions", {
+        configurable: true,
+        value: fakePermissions,
+      });
+    }
+
+    activeRestore = () => {
+      if (originalMediaDevices) {
+        Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+      }
+      if (originalPermissions) {
+        Object.defineProperty(navigator, "permissions", originalPermissions);
+      }
+    };
+
+    return { fakeMediaDevices, trackStop };
+  };
+
+  const restore = (): void => {
+    activeRestore?.();
+    activeRestore = null;
+  };
+
+  return { install, restore };
 }
 
 describe("primeMicStream", () => {
+  const env = createNavigatorSandbox();
+
   afterEach(() => {
     sinon.restore();
-    restoreNavigator();
+    env.restore();
   });
 
   it("throws when microphone permission is denied", async () => {
-    const { fakeMediaDevices } = installFakeNavigator({
+    const { fakeMediaDevices } = env.install({
       enumerateResults: [],
       permissionState: "denied",
     });
@@ -148,7 +166,7 @@ describe("primeMicStream", () => {
   });
 
   it("opens and stops a stream when permission is 'prompt'", async () => {
-    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+    const { fakeMediaDevices, trackStop } = env.install({
       enumerateResults: [],
       permissionState: "prompt",
     });
@@ -160,7 +178,7 @@ describe("primeMicStream", () => {
   });
 
   it("opens and stops a stream when permission is already 'granted'", async () => {
-    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+    const { fakeMediaDevices, trackStop } = env.install({
       enumerateResults: [],
       permissionState: "granted",
     });
@@ -172,7 +190,7 @@ describe("primeMicStream", () => {
   });
 
   it("opens a stream when the Permissions API is unavailable", async () => {
-    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+    const { fakeMediaDevices, trackStop } = env.install({
       enumerateResults: [],
       permissionState: "unavailable",
     });
@@ -182,18 +200,37 @@ describe("primeMicStream", () => {
     expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
     expect(trackStop.calledOnce).to.equal(true);
   });
+
+  it("propagates a runtime getUserMedia rejection (e.g. NotReadableError)", async () => {
+    env.install({
+      enumerateResults: [],
+      getUserMediaRejection: new Error("NotReadableError"),
+      permissionState: "granted",
+    });
+
+    let error: Error | undefined;
+    try {
+      await primeMicStream();
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error?.message).to.equal("NotReadableError");
+  });
 });
 
 describe("getAudioDevices", () => {
+  const env = createNavigatorSandbox();
+
   afterEach(() => {
     sinon.restore();
-    restoreNavigator();
+    env.restore();
   });
 
   // Chrome / Safari path: enumerateDevices returns populated entries on the
   // first call, so we should not invoke getUserMedia at all.
   it("returns devices without priming when entries are already populated", async () => {
-    const { fakeMediaDevices } = installFakeNavigator({
+    const { fakeMediaDevices } = env.install({
       enumerateResults: [[...REAL_DEVICES, ...NON_AUDIO_DEVICES]],
       permissionState: "granted",
     });
@@ -211,7 +248,7 @@ describe("getAudioDevices", () => {
   // even when permission is granted; only after getUserMedia does
   // enumerateDevices return the real devices.
   it("primes with getUserMedia and re-enumerates when Firefox returns a placeholder", async () => {
-    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+    const { fakeMediaDevices, trackStop } = env.install({
       enumerateResults: [[FIREFOX_PLACEHOLDER], REAL_DEVICES],
       permissionState: "granted",
     });
@@ -227,7 +264,7 @@ describe("getAudioDevices", () => {
 
   it("primes when any audio input has a blank label but a real deviceId", async () => {
     const blankLabel = audioInput("mic1", "");
-    const { fakeMediaDevices } = installFakeNavigator({
+    const { fakeMediaDevices } = env.install({
       enumerateResults: [[blankLabel], REAL_DEVICES],
       permissionState: "granted",
     });
@@ -239,7 +276,7 @@ describe("getAudioDevices", () => {
   });
 
   it("does not call getUserMedia when no audio inputs exist", async () => {
-    const { fakeMediaDevices } = installFakeNavigator({
+    const { fakeMediaDevices } = env.install({
       enumerateResults: [NON_AUDIO_DEVICES],
       permissionState: "granted",
     });
@@ -252,7 +289,7 @@ describe("getAudioDevices", () => {
   });
 
   it("propagates the denied error when priming is needed but permission is denied", async () => {
-    const { fakeMediaDevices } = installFakeNavigator({
+    const { fakeMediaDevices } = env.install({
       enumerateResults: [[FIREFOX_PLACEHOLDER]],
       permissionState: "denied",
     });
@@ -266,5 +303,22 @@ describe("getAudioDevices", () => {
 
     expect(error?.message).to.equal("Microphone permission is denied");
     expect(fakeMediaDevices.getUserMedia.called).to.equal(false);
+  });
+
+  it("propagates a runtime getUserMedia rejection when priming is needed", async () => {
+    env.install({
+      enumerateResults: [[FIREFOX_PLACEHOLDER]],
+      getUserMediaRejection: new Error("NotReadableError"),
+      permissionState: "granted",
+    });
+
+    let error: Error | undefined;
+    try {
+      await getAudioDevices();
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error?.message).to.equal("NotReadableError");
   });
 });

--- a/test/devices.test.ts
+++ b/test/devices.test.ts
@@ -1,0 +1,270 @@
+import { expect } from "@open-wc/testing";
+import * as sinon from "sinon";
+import { getAudioDevices, requestMicAccess } from "../src/utils/devices.js";
+
+interface FakeMediaDevices {
+  getUserMedia: sinon.SinonStub;
+  enumerateDevices: sinon.SinonStub;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+}
+
+interface FakePermissions {
+  query: sinon.SinonStub;
+}
+
+const audioInput = (deviceId: string, label: string): MediaDeviceInfo => ({
+  deviceId,
+  groupId: deviceId === "" ? "" : `group-${deviceId}`,
+  kind: "audioinput",
+  label,
+  toJSON: () => ({}),
+});
+
+const FIREFOX_PLACEHOLDER: MediaDeviceInfo = audioInput("", "");
+
+const REAL_DEVICES: MediaDeviceInfo[] = [
+  audioInput("mic1", "MacBook Pro Microphone"),
+  audioInput("mic2", "ZoomAudioDevice"),
+];
+
+const NON_AUDIO_DEVICES: MediaDeviceInfo[] = [
+  {
+    deviceId: "speaker1",
+    groupId: "group-speaker1",
+    kind: "audiooutput",
+    label: "Speaker",
+    toJSON: () => ({}),
+  } as MediaDeviceInfo,
+  {
+    deviceId: "cam1",
+    groupId: "group-cam1",
+    kind: "videoinput",
+    label: "Webcam",
+    toJSON: () => ({}),
+  } as MediaDeviceInfo,
+];
+
+let originalMediaDevices: PropertyDescriptor | undefined;
+let originalPermissions: PropertyDescriptor | undefined;
+
+function installFakeNavigator(opts: {
+  permissionState?: PermissionState | "unavailable";
+  enumerateResults: MediaDeviceInfo[][];
+  getUserMediaRejection?: Error;
+}): { fakeMediaDevices: FakeMediaDevices; trackStop: sinon.SinonSpy } {
+  const trackStop = sinon.spy();
+  const fakeStream = {
+    getTracks: () => [{ stop: trackStop }],
+  } as unknown as MediaStream;
+
+  const enumerateStub = sinon.stub();
+  opts.enumerateResults.forEach((result, i) => {
+    enumerateStub.onCall(i).resolves(result);
+  });
+  const lastResult =
+    opts.enumerateResults[opts.enumerateResults.length - 1] ?? [];
+  enumerateStub.resolves(lastResult);
+
+  const getUserMediaStub = sinon.stub();
+  if (opts.getUserMediaRejection) {
+    getUserMediaStub.rejects(opts.getUserMediaRejection);
+  } else {
+    getUserMediaStub.resolves(fakeStream);
+  }
+
+  const fakeMediaDevices: FakeMediaDevices = {
+    addEventListener: () => {},
+    enumerateDevices: enumerateStub,
+    getUserMedia: getUserMediaStub,
+    removeEventListener: () => {},
+  };
+
+  originalMediaDevices = Object.getOwnPropertyDescriptor(
+    navigator,
+    "mediaDevices",
+  );
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: fakeMediaDevices,
+  });
+
+  originalPermissions = Object.getOwnPropertyDescriptor(
+    navigator,
+    "permissions",
+  );
+  if (opts.permissionState === "unavailable") {
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: undefined,
+    });
+  } else {
+    const fakePermissions: FakePermissions = {
+      query: sinon
+        .stub()
+        .resolves({ state: opts.permissionState ?? "granted" }),
+    };
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: fakePermissions,
+    });
+  }
+
+  return { fakeMediaDevices, trackStop };
+}
+
+function restoreNavigator(): void {
+  if (originalMediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+    originalMediaDevices = undefined;
+  }
+  if (originalPermissions) {
+    Object.defineProperty(navigator, "permissions", originalPermissions);
+    originalPermissions = undefined;
+  }
+}
+
+describe("requestMicAccess", () => {
+  afterEach(() => {
+    sinon.restore();
+    restoreNavigator();
+  });
+
+  it("throws when microphone permission is denied", async () => {
+    const { fakeMediaDevices } = installFakeNavigator({
+      enumerateResults: [],
+      permissionState: "denied",
+    });
+
+    let error: Error | undefined;
+    try {
+      await requestMicAccess();
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error?.message).to.equal("Microphone permission is denied");
+    expect(fakeMediaDevices.getUserMedia.called).to.equal(false);
+  });
+
+  it("opens and stops a stream when permission is 'prompt'", async () => {
+    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+      enumerateResults: [],
+      permissionState: "prompt",
+    });
+
+    await requestMicAccess();
+
+    expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
+    expect(trackStop.calledOnce).to.equal(true);
+  });
+
+  it("opens and stops a stream when permission is already 'granted'", async () => {
+    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+      enumerateResults: [],
+      permissionState: "granted",
+    });
+
+    await requestMicAccess();
+
+    expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
+    expect(trackStop.calledOnce).to.equal(true);
+  });
+
+  it("opens a stream when the Permissions API is unavailable", async () => {
+    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+      enumerateResults: [],
+      permissionState: "unavailable",
+    });
+
+    await requestMicAccess();
+
+    expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
+    expect(trackStop.calledOnce).to.equal(true);
+  });
+});
+
+describe("getAudioDevices", () => {
+  afterEach(() => {
+    sinon.restore();
+    restoreNavigator();
+  });
+
+  // Chrome / Safari path: enumerateDevices returns populated entries on the
+  // first call, so we should not invoke getUserMedia at all.
+  it("returns devices without priming when entries are already populated", async () => {
+    const { fakeMediaDevices } = installFakeNavigator({
+      enumerateResults: [[...REAL_DEVICES, ...NON_AUDIO_DEVICES]],
+      permissionState: "granted",
+    });
+
+    const { devices, defaultDevice } = await getAudioDevices();
+
+    expect(fakeMediaDevices.enumerateDevices.callCount).to.equal(1);
+    expect(fakeMediaDevices.getUserMedia.called).to.equal(false);
+    expect(devices.map((d) => d.deviceId)).to.deep.equal(["mic1", "mic2"]);
+    expect(defaultDevice?.deviceId).to.equal("mic1");
+  });
+
+  // Regression for DXG-831. Models Firefox's actual behavior: cold
+  // enumerateDevices returns a single placeholder with empty deviceId/label
+  // even when permission is granted; only after getUserMedia does
+  // enumerateDevices return the real devices.
+  it("primes with getUserMedia and re-enumerates when Firefox returns a placeholder", async () => {
+    const { fakeMediaDevices, trackStop } = installFakeNavigator({
+      enumerateResults: [[FIREFOX_PLACEHOLDER], REAL_DEVICES],
+      permissionState: "granted",
+    });
+
+    const { devices, defaultDevice } = await getAudioDevices();
+
+    expect(fakeMediaDevices.enumerateDevices.callCount).to.equal(2);
+    expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
+    expect(trackStop.calledOnce).to.equal(true);
+    expect(devices.map((d) => d.deviceId)).to.deep.equal(["mic1", "mic2"]);
+    expect(defaultDevice?.label).to.equal("MacBook Pro Microphone");
+  });
+
+  it("primes when any audio input has a blank label but a real deviceId", async () => {
+    const blankLabel = audioInput("mic1", "");
+    const { fakeMediaDevices } = installFakeNavigator({
+      enumerateResults: [[blankLabel], REAL_DEVICES],
+      permissionState: "granted",
+    });
+
+    await getAudioDevices();
+
+    expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
+    expect(fakeMediaDevices.enumerateDevices.callCount).to.equal(2);
+  });
+
+  it("does not call getUserMedia when no audio inputs exist", async () => {
+    const { fakeMediaDevices } = installFakeNavigator({
+      enumerateResults: [NON_AUDIO_DEVICES],
+      permissionState: "granted",
+    });
+
+    const { devices, defaultDevice } = await getAudioDevices();
+
+    expect(fakeMediaDevices.getUserMedia.called).to.equal(false);
+    expect(devices).to.deep.equal([]);
+    expect(defaultDevice).to.equal(undefined);
+  });
+
+  it("propagates the denied error when priming is needed but permission is denied", async () => {
+    const { fakeMediaDevices } = installFakeNavigator({
+      enumerateResults: [[FIREFOX_PLACEHOLDER]],
+      permissionState: "denied",
+    });
+
+    let error: Error | undefined;
+    try {
+      await getAudioDevices();
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error?.message).to.equal("Microphone permission is denied");
+    expect(fakeMediaDevices.getUserMedia.called).to.equal(false);
+  });
+});

--- a/test/devices.test.ts
+++ b/test/devices.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@open-wc/testing";
 import * as sinon from "sinon";
-import { getAudioDevices, requestMicAccess } from "../src/utils/devices.js";
+import { getAudioDevices, primeMicStream } from "../src/utils/devices.js";
 
 interface FakeMediaDevices {
   getUserMedia: sinon.SinonStub;
@@ -124,7 +124,7 @@ function restoreNavigator(): void {
   }
 }
 
-describe("requestMicAccess", () => {
+describe("primeMicStream", () => {
   afterEach(() => {
     sinon.restore();
     restoreNavigator();
@@ -138,7 +138,7 @@ describe("requestMicAccess", () => {
 
     let error: Error | undefined;
     try {
-      await requestMicAccess();
+      await primeMicStream();
     } catch (e) {
       error = e as Error;
     }
@@ -153,7 +153,7 @@ describe("requestMicAccess", () => {
       permissionState: "prompt",
     });
 
-    await requestMicAccess();
+    await primeMicStream();
 
     expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
     expect(trackStop.calledOnce).to.equal(true);
@@ -165,7 +165,7 @@ describe("requestMicAccess", () => {
       permissionState: "granted",
     });
 
-    await requestMicAccess();
+    await primeMicStream();
 
     expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
     expect(trackStop.calledOnce).to.equal(true);
@@ -177,7 +177,7 @@ describe("requestMicAccess", () => {
       permissionState: "unavailable",
     });
 
-    await requestMicAccess();
+    await primeMicStream();
 
     expect(fakeMediaDevices.getUserMedia.calledOnce).to.equal(true);
     expect(trackStop.calledOnce).to.equal(true);


### PR DESCRIPTION
## Summary

After a page reload in Firefox, the dictation web component shows an empty mic device list even when permission was previously granted. This change detects Firefox's pre-permission placeholder and primes the document with `getUserMedia()` only when needed. Chrome and Safari are unchanged.

Resolves [DXG-831](https://linear.app/corti/issue/DXG-831)

## Root cause

`getAudioDevices()` called `requestMicAccess()`, which short-circuited when the Permissions API reported `granted` and never invoked `getUserMedia()`. Firefox keeps device info hidden behind an active media stream regardless of persisted permission, so on reload `enumerateDevices()` returns one placeholder entry with empty `deviceId` and empty `label` — which propagates downstream as an unselectable "blank" device, surfacing as an empty list in the UI.

Confirmed in a real Firefox session via a diagnostic Storybook story (separate, not in this PR):

| Snapshot                 | permission state | audio inputs | blank labels |
| ------------------------ | ---------------- | ------------ | ------------ |
| Cold (no `getUserMedia`) | `granted`        | 1            | 1            |
| After `getUserMedia`     | `granted`        | 2            | 0            |

## Solution

`getAudioDevices()` now enumerates first; primes a stream only when the result matches Firefox's placeholder pattern:

```ts
let audioDevices = await listAudioInputs();

if (needsMicPriming(audioDevices)) {
  await primeMicStream();
  audioDevices = await listAudioInputs();
}
```

`needsMicPriming` returns true when any audio input has an empty `deviceId` or empty `label`, but returns `false` on a genuinely empty list — so machines without a mic don't trigger a useless `getUserMedia` call.

## Notable Implementation Details

- **Self-healing within a Firefox session** — once the stream is primed, subsequent calls (e.g. on `devicechange`) return real entries directly; no second prime.
- **`requestMicAccess()` renamed to `primeMicStream()`** — now always opens (and immediately stops) a stream, except on `denied` (early throw, unchanged behavior). The previous "skip on granted" branch was the bug and is gone; the new name matches the function's actual role. Not a breaking change — the function is not on the package's public `exports` surface.
- **Test models the Firefox sequence** — `enumerateDevices` is stubbed to return the placeholder on the cold call and real devices on the second; the regression test would have caught the original bug.
- **Error-path coverage** — tests now also exercise runtime `getUserMedia` rejections (e.g. `NotReadableError` when another app holds the mic), in addition to the Permissions API `denied` path.
