### PR TITLE
chore: upgrade @corti/sdk to 4.0.0

### DIFF
--- a/RELEASE_NOTES_DRAFT.md
+++ b/RELEASE_NOTES_DRAFT.md
@@ -1,0 +1,24 @@
+## Release 0.8.0
+
+## Overview
+
+`@corti/dictation-web` and `@corti/ambient-web` now depend on stable `@corti/sdk@4.0.0`. Ambient default and virtual-mode stream configuration uses the SDK v4 `diarize` field instead of the removed `isDiarization` option.
+
+## ❗ Breaking changes
+
+- **SDK v4 required**: Both packages now depend on `@corti/sdk@4.0.0`. Upgrade your app’s SDK dependency when upgrading these components.
+  - **Migration**: Bump `@corti/sdk` to `4.0.0` (or newer) alongside `@corti/dictation-web` / `@corti/ambient-web`.
+  - **Example**:
+    - Before: `"@corti/sdk": "3.0.0", "@corti/ambient-web": "0.7.0"`
+    - After: `"@corti/sdk": "4.0.0", "@corti/ambient-web": "0.8.0"`
+
+- **Ambient `isDiarization` removed**: Default ambient config and virtual-mode toggling now set `transcription.diarize` per SDK v4.
+  - **Migration**: If you pass a custom `ambientConfig` (or merge into `Corti.StreamConfig`), rename `transcription.isDiarization` to `transcription.diarize`.
+  - **Example**:
+    - Before: `transcription: { isDiarization: true, primaryLanguage: "en" }`
+    - After: `transcription: { diarize: true, primaryLanguage: "en" }`
+
+## Changes
+
+- chore(ambient): use `transcription.diarize` in `DEFAULT_AMBIENT_CONFIG` and virtual-mode config helper.
+- chore(deps): bump `@corti/sdk` from `3.0.0` to `4.0.0` in `@corti/dictation-web` and `@corti/ambient-web`.

--- a/ambient/package.json
+++ b/ambient/package.json
@@ -41,7 +41,7 @@
     "real-time"
   ],
   "dependencies": {
-    "@corti/sdk": "3.0.0",
+    "@corti/sdk": "4.0.0",
     "@lit/context": "^1.1.6",
     "lit": "^3.3.3"
   },

--- a/ambient/src/constants.ts
+++ b/ambient/src/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_VIRTUAL_MODE_PARTICIPANTS: Corti.StreamConfigParticipant[] 
 export const DEFAULT_AMBIENT_CONFIG: Corti.StreamConfig = {
   mode: { outputLocale: "en", type: "facts" },
   transcription: {
-    isDiarization: true,
+    diarize: true,
     isMultichannel: false,
     participants: [],
     primaryLanguage: "en",

--- a/ambient/src/utils/virtual-mode-config.ts
+++ b/ambient/src/utils/virtual-mode-config.ts
@@ -12,7 +12,7 @@ export function applyVirtualModeToAmbientConfig(
       ...base,
       transcription: {
         ...base.transcription,
-        isDiarization: false,
+        diarize: false,
         isMultichannel: true,
         participants: existingParticipants?.length
           ? existingParticipants
@@ -25,7 +25,7 @@ export function applyVirtualModeToAmbientConfig(
     ...base,
     transcription: {
       ...base.transcription,
-      isDiarization: true,
+      diarize: true,
       isMultichannel: false,
       participants:
         existingParticipants === DEFAULT_VIRTUAL_MODE_PARTICIPANTS

--- a/dictation/package.json
+++ b/dictation/package.json
@@ -40,7 +40,7 @@
     "healthcare"
   ],
   "dependencies": {
-    "@corti/sdk": "3.0.0",
+    "@corti/sdk": "4.0.0",
     "@lit/context": "^1.1.6",
     "lit": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook:build": "tsc -b core && tsc -p tsconfig.stories.json && pnpm run analyze && storybook build"
   },
   "devDependencies": {
-    "@corti/sdk": "3.0.0",
+    "@corti/sdk": "4.0.0",
     "@lit/context": "^1.1.6",
     "@biomejs/biome": "^2.3.6",
     "@custom-elements-manifest/analyzer": "^0.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.3.6
         version: 2.4.16
       '@corti/sdk':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 4.0.0
+        version: 4.0.0
       '@custom-elements-manifest/analyzer':
         specifier: ^0.10.3
         version: 0.10.10
@@ -84,8 +84,8 @@ importers:
   ambient:
     dependencies:
       '@corti/sdk':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 4.0.0
+        version: 4.0.0
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -96,8 +96,8 @@ importers:
   dictation:
     dependencies:
       '@corti/sdk':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 4.0.0
+        version: 4.0.0
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -188,8 +188,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@corti/sdk@3.0.0':
-    resolution: {integrity: sha512-MWuhqsU/G8DGARrq8eMfm9GjwsrKvvvKKymeP+WxaV3wGNogWWPBidrtScIabjo64Okv7+79gxArelwUc2X8VQ==}
+  '@corti/sdk@4.0.0':
+    resolution: {integrity: sha512-XE5wbaUAoYNBvXqu4LP/k51veuzkOvNW/cBgxi2WgERzYC01cc0rAULWjcPR4Uh0xXaNMQi/XAeknbWZch5tww==}
     engines: {node: '>=18.0.0'}
 
   '@custom-elements-manifest/analyzer@0.10.10':
@@ -3874,7 +3874,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
-  '@corti/sdk@3.0.0':
+  '@corti/sdk@4.0.0':
     dependencies:
       ws: 8.21.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bump `@corti/sdk` from `3.0.0` to `4.0.0` in root, `@corti/dictation-web`, and `@corti/ambient-web`
- Rename ambient transcription config field `isDiarization` → `diarize` to match SDK v4

## Test plan
- [x] `pnpm install`
- [x] `pnpm run build`
- [x] `pnpm test` (11/11 pass)
- [ ] Merge and tag `v0.8.0` for npm publish (current latest is `0.7.0`)