### PR TITLE
feat: load languages from GET /languages and send web-component analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           (cd dictation && pnpm version "$VERSION" --no-git-tag-version)
           (cd ambient && pnpm version "$VERSION" --no-git-tag-version)
+          sed -i "s/WEB_COMPONENT_VERSION = \"[^\"]*\"/WEB_COMPONENT_VERSION = \"${VERSION}\"/" dictation/src/version.ts ambient/src/version.ts
           echo "dictation: $(node -p "require('./dictation/package.json').version")"
           echo "ambient: $(node -p "require('./ambient/package.json').version")"
 

--- a/ambient/package.json
+++ b/ambient/package.json
@@ -41,7 +41,7 @@
     "real-time"
   ],
   "dependencies": {
-    "@corti/sdk": "4.0.0",
+    "@corti/sdk": "5.0.0",
     "@lit/context": "^1.1.6",
     "lit": "^3.3.3"
   },

--- a/ambient/src/components/corti-ambient.ts
+++ b/ambient/src/components/corti-ambient.ts
@@ -100,6 +100,7 @@ export class CortiAmbient extends CortiRoot<
         class=${classMap({ hidden: isHidden })}
         .accessToken=${this.accessToken}
         .authConfig=${this.authConfig}
+        .analytics=${this.analytics}
         .socketUrl=${this.socketUrl}
         .socketProxy=${this.socketProxy}
         .ambientConfig=${this._ambientConfig}

--- a/ambient/src/components/corti-ambient.ts
+++ b/ambient/src/components/corti-ambient.ts
@@ -9,6 +9,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { ref } from "lit/directives/ref.js";
 import { DEFAULT_AMBIENT_CONFIG } from "../constants.js";
 import type { AmbientRoot } from "../contexts/ambient-context.js";
+import { WEB_COMPONENT_VERSION } from "../version.js";
 import type { AmbientRecordingButton } from "./ambient-recording-button.js";
 
 import "../contexts/ambient-context.js";
@@ -23,6 +24,13 @@ export class CortiAmbient extends CortiRoot<
   // ─────────────────────────────────────────────────────────────────────────────
   // Properties
   // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Published package version. `0.0.0-dev` in local builds.
+   */
+  get version(): string {
+    return WEB_COMPONENT_VERSION;
+  }
 
   @property({
     converter: commaSeparatedConverter,

--- a/ambient/src/contexts/ambient-context.ts
+++ b/ambient/src/contexts/ambient-context.ts
@@ -26,6 +26,13 @@ export class AmbientRoot extends RootContext {
   @state()
   _analytics = speechAnalytics(WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION);
 
+  /**
+   * Published package version. `0.0.0-dev` in local builds.
+   */
+  get version(): string {
+    return WEB_COMPONENT_VERSION;
+  }
+
   @provide({ context: ambientConfigContext })
   @property({ attribute: false, type: Object })
   ambientConfig: Corti.StreamConfig = DEFAULT_AMBIENT_CONFIG;

--- a/ambient/src/contexts/ambient-context.ts
+++ b/ambient/src/contexts/ambient-context.ts
@@ -1,11 +1,14 @@
+import { analyticsContext } from "@core/contexts/mixins/analytics-context.js";
 import { RootContext } from "@core/contexts/root-context.js";
+import { speechAnalytics } from "@core/utils/analytics.js";
 import { safeCustomElement } from "@core/utils/custom-elements.js";
 import type { Corti } from "@corti/sdk";
 import { createContext, provide } from "@lit/context";
 import type { PropertyValues } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { DEFAULT_AMBIENT_CONFIG } from "../constants.js";
 import { applyVirtualModeToAmbientConfig } from "../utils/virtual-mode-config.js";
+import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export const ambientConfigContext = createContext<
   Corti.StreamConfig | undefined
@@ -19,6 +22,10 @@ export const virtualModeContext = createContext<boolean>(Symbol("virtualMode"));
 
 @safeCustomElement("ambient-root")
 export class AmbientRoot extends RootContext {
+  @provide({ context: analyticsContext })
+  @state()
+  _analytics = speechAnalytics(WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION);
+
   @provide({ context: ambientConfigContext })
   @property({ attribute: false, type: Object })
   ambientConfig: Corti.StreamConfig = DEFAULT_AMBIENT_CONFIG;

--- a/ambient/src/contexts/ambient-context.ts
+++ b/ambient/src/contexts/ambient-context.ts
@@ -76,6 +76,14 @@ export class AmbientRoot extends RootContext {
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
 
+    if (changedProperties.has("analytics")) {
+      this._analytics = speechAnalytics(
+        WEB_COMPONENT_NAME,
+        WEB_COMPONENT_VERSION,
+        this.analytics,
+      );
+    }
+
     if (changedProperties.has("virtualMode")) {
       const base = this.ambientConfig ?? DEFAULT_AMBIENT_CONFIG;
       this.ambientConfig = applyVirtualModeToAmbientConfig(

--- a/ambient/src/controllers/ambient-controller.ts
+++ b/ambient/src/controllers/ambient-controller.ts
@@ -1,11 +1,13 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { StreamAmbientMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
+import { proxyWithAnalytics, speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
   CortiWebSocketProxyClient,
 } from "@corti/sdk";
+import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export type { StreamAmbientMessage } from "@core/socket-messages.js";
 
@@ -26,6 +28,11 @@ export class AmbientController extends SocketController<
   AmbientStreamSessionConfig,
   AmbientStreamSocket
 > {
+  protected readonly _analytics = speechAnalytics(
+    WEB_COMPONENT_NAME,
+    WEB_COMPONENT_VERSION,
+  );
+
   async stopRecording(): Promise<void> {
     await this.closeConnection();
   }
@@ -38,7 +45,7 @@ export class AmbientController extends SocketController<
       // awaitConfiguration: false — CONFIG_* appears in network activity before the socket is configured server-side
       awaitConfiguration: false,
       configuration: session.configuration,
-      proxy,
+      proxy: proxyWithAnalytics(proxy, this._analytics),
     });
   }
 

--- a/ambient/src/controllers/ambient-controller.ts
+++ b/ambient/src/controllers/ambient-controller.ts
@@ -1,13 +1,11 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { StreamAmbientMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
-import { speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
   CortiWebSocketProxyClient,
 } from "@corti/sdk";
-import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export type { StreamAmbientMessage } from "@core/socket-messages.js";
 
@@ -28,11 +26,6 @@ export class AmbientController extends SocketController<
   AmbientStreamSessionConfig,
   AmbientStreamSocket
 > {
-  protected readonly _analytics = speechAnalytics(
-    WEB_COMPONENT_NAME,
-    WEB_COMPONENT_VERSION,
-  );
-
   async stopRecording(): Promise<void> {
     await this.closeConnection();
   }

--- a/ambient/src/controllers/ambient-controller.ts
+++ b/ambient/src/controllers/ambient-controller.ts
@@ -1,7 +1,7 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { StreamAmbientMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
-import { proxyWithAnalytics, speechAnalytics } from "@core/utils/analytics.js";
+import { speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
@@ -45,7 +45,7 @@ export class AmbientController extends SocketController<
       // awaitConfiguration: false — CONFIG_* appears in network activity before the socket is configured server-side
       awaitConfiguration: false,
       configuration: session.configuration,
-      proxy: proxyWithAnalytics(proxy, this._analytics),
+      proxy,
     });
   }
 

--- a/ambient/src/version.ts
+++ b/ambient/src/version.ts
@@ -1,0 +1,2 @@
+export const WEB_COMPONENT_NAME = "@corti/ambient-web";
+export const WEB_COMPONENT_VERSION = "0.0.0-dev";

--- a/core/src/components/corti-root.ts
+++ b/core/src/components/corti-root.ts
@@ -69,6 +69,13 @@ export class CortiRoot<
   socketProxy?: ProxyOptions;
 
   /**
+   * Extra keys on `x-corti-analytics`. `web_component` and
+   * `web_component_version` are reserved by the component.
+   */
+  @property({ attribute: false, type: Object })
+  analytics?: Record<string, string>;
+
+  /**
    * Which settings should be available in the UI.
    *  If an empty array is passed, the settings will be disabled entirely.
    */

--- a/core/src/components/recording-button-base.ts
+++ b/core/src/components/recording-button-base.ts
@@ -9,6 +9,7 @@ import {
 } from "lit";
 import { property, state } from "lit/decorators.js";
 import { AUDIO_CHUNK_INTERVAL_MS } from "../constants.js";
+import { analyticsContext } from "../contexts/mixins/analytics-context.js";
 import {
   accessTokenContext,
   authConfigContext,
@@ -82,6 +83,10 @@ export abstract class RecordingButtonBase<
   @consume({ context: selectedDeviceContext, subscribe: true })
   @state()
   _selectedDevice?: MediaDeviceInfo;
+
+  @consume({ context: analyticsContext, subscribe: true })
+  @state()
+  _analytics?: Record<string, string>;
 
   @consume({ context: accessTokenContext, subscribe: true })
   @state()

--- a/core/src/contexts/mixins/analytics-context.ts
+++ b/core/src/contexts/mixins/analytics-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from "@lit/context";
+
+export const analyticsContext = createContext<
+  Record<string, string> | undefined
+>(Symbol("analytics"));

--- a/core/src/contexts/root-context.ts
+++ b/core/src/contexts/root-context.ts
@@ -18,6 +18,13 @@ export class RootContext extends DevicesContextMixin(
   @property({ type: Boolean })
   noWrapper: boolean = false;
 
+  /**
+   * Extra keys on `x-corti-analytics`. `web_component` and
+   * `web_component_version` are reserved by the component.
+   */
+  @property({ attribute: false, type: Object })
+  analytics?: Record<string, string>;
+
   static styles: CSSResultGroup = [ComponentStyles];
 
   render() {

--- a/core/src/controllers/languages-controller.ts
+++ b/core/src/controllers/languages-controller.ts
@@ -1,20 +1,29 @@
-import type { Corti } from "@corti/sdk";
+import { type Corti, type CortiAuth, CortiClient } from "@corti/sdk";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { errorEvent, languagesChangedEvent } from "../utils/events.js";
-import { getLanguagesByRegion } from "../utils/languages.js";
+import {
+  enabledLanguageCodes,
+  getLanguagesByRegion,
+  getPreferredDefaultLanguage,
+} from "../utils/languages.js";
 
 interface LanguagesControllerHost extends ReactiveControllerHost {
+  localName: string;
   region?: string;
+  tenantName?: string;
   dispatchEvent(event: CustomEvent): boolean;
   requestUpdate(): void;
+  _accessToken?: string;
+  _analytics?: Record<string, string>;
+  _authConfig?: CortiAuth.AuthTokenDerivable;
   _languages?: Corti.TranscribeSupportedLanguage[];
   _selectedLanguage?: Corti.TranscribeSupportedLanguage;
 }
 
 /**
- * Controller that manages automatic language loading based on region.
- * Loads languages when they're not present and handles region changes.
- * Reacts to updates and automatically loads languages when needed.
+ * Controller that manages automatic language loading.
+ * Prefers GET /languages when auth is available. Falls back to the region list
+ * only when the request is skipped (no auth) or fails. An empty API list is kept.
  */
 export class LanguagesController implements ReactiveController {
   host: LanguagesControllerHost;
@@ -62,9 +71,21 @@ export class LanguagesController implements ReactiveController {
     this.#loadingLanguages = true;
 
     try {
-      const { languages, defaultLanguage } = getLanguagesByRegion(
-        this.host.region,
-      );
+      let languages: Corti.TranscribeSupportedLanguage[] | undefined;
+
+      try {
+        languages = await this.#languagesFromApi();
+      } catch (error) {
+        this.host.dispatchEvent(
+          errorEvent(
+            `Failed to load languages from API, using region defaults: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        );
+      }
+
+      languages ??= getLanguagesByRegion(this.host.region).languages;
 
       this.#autoLoadedLanguages = true;
       this.host._languages = languages;
@@ -73,7 +94,7 @@ export class LanguagesController implements ReactiveController {
       const selectedLanguage =
         previousLanguage && languages.includes(previousLanguage)
           ? previousLanguage
-          : defaultLanguage;
+          : getPreferredDefaultLanguage(languages);
 
       this.host._selectedLanguage = selectedLanguage;
       this.host.requestUpdate();
@@ -85,6 +106,50 @@ export class LanguagesController implements ReactiveController {
     } finally {
       this.#loadingLanguages = false;
     }
+  }
+
+  async #languagesFromApi(): Promise<
+    Corti.TranscribeSupportedLanguage[] | undefined
+  > {
+    if (!this.host._authConfig && !this.host._accessToken) {
+      return;
+    }
+
+    const endpoint = this.#languagesListEndpoint();
+
+    if (!endpoint) {
+      return;
+    }
+
+    const auth: CortiAuth.AuthTokenDerivable = this.host._authConfig || {
+      accessToken: this.host._accessToken || "",
+      refreshAccessToken: () => ({
+        accessToken: this.host._accessToken || "",
+      }),
+    };
+
+    const client = new CortiClient({
+      analytics: this.host._analytics,
+      auth,
+      environment: this.host.region,
+      tenantName: this.host.tenantName,
+    });
+
+    const result = await client.languages.list({ endpoint });
+
+    return enabledLanguageCodes(result.languages, endpoint);
+  }
+
+  #languagesListEndpoint(): Corti.LanguagesListRequestEndpoint | undefined {
+    if (this.host.localName === "ambient-root") {
+      return "streams";
+    }
+
+    if (this.host.localName === "dictation-root") {
+      return "transcribe";
+    }
+
+    return undefined;
   }
 
   /**

--- a/core/src/controllers/languages-controller.ts
+++ b/core/src/controllers/languages-controller.ts
@@ -2,9 +2,9 @@ import { type Corti, type CortiAuth, CortiClient } from "@corti/sdk";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { errorEvent, languagesChangedEvent } from "../utils/events.js";
 import {
-  enabledLanguageCodes,
   getLanguagesByRegion,
   getPreferredDefaultLanguage,
+  languageCodesFromList,
 } from "../utils/languages.js";
 
 interface LanguagesControllerHost extends ReactiveControllerHost {
@@ -137,7 +137,7 @@ export class LanguagesController implements ReactiveController {
 
     const result = await client.languages.list({ endpoint });
 
-    return enabledLanguageCodes(result.languages, endpoint);
+    return languageCodesFromList(result.languages);
   }
 
   #languagesListEndpoint(): Corti.LanguagesListRequestEndpoint | undefined {

--- a/core/src/controllers/socket-controller.ts
+++ b/core/src/controllers/socket-controller.ts
@@ -54,6 +54,7 @@ export abstract class SocketController<
   #connectingPromise: Promise<boolean | "superseded"> | null = null;
   #isConnecting = false;
 
+  protected abstract readonly _analytics: Record<string, string>;
   protected abstract _connectThroughProxy(
     config: TConfig,
     proxy: ProxyOptions,
@@ -95,6 +96,7 @@ export abstract class SocketController<
     };
 
     this.#cortiClient = new CortiClient({
+      analytics: this._analytics,
       auth,
       environment: this.host._region,
       tenantName: this.host._tenantName,

--- a/core/src/controllers/socket-controller.ts
+++ b/core/src/controllers/socket-controller.ts
@@ -1,6 +1,7 @@
 import { type CortiAuth, CortiClient } from "@corti/sdk";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ProxyOptions } from "../types.js";
+import { proxyWithAnalytics } from "../utils/analytics.js";
 import { errorEvent } from "../utils/events.js";
 
 export interface SocketControllerHost extends ReactiveControllerHost {
@@ -78,7 +79,10 @@ export abstract class SocketController<
       throw new Error("Proxy URL is required when using proxy client");
     }
 
-    return this._connectThroughProxy(config, proxyOptions);
+    return this._connectThroughProxy(
+      config,
+      proxyWithAnalytics(proxyOptions, this._analytics),
+    );
   }
 
   async #openViaAuth(config: TConfig): Promise<TSocket> {

--- a/core/src/controllers/socket-controller.ts
+++ b/core/src/controllers/socket-controller.ts
@@ -81,9 +81,7 @@ export abstract class SocketController<
 
     return this._connectThroughProxy(
       config,
-      this.host._analytics
-        ? proxyWithAnalytics(proxyOptions, this.host._analytics)
-        : proxyOptions,
+      proxyWithAnalytics(proxyOptions, this.host._analytics),
     );
   }
 

--- a/core/src/controllers/socket-controller.ts
+++ b/core/src/controllers/socket-controller.ts
@@ -7,6 +7,7 @@ import { errorEvent } from "../utils/events.js";
 export interface SocketControllerHost extends ReactiveControllerHost {
   dispatchEvent: (event: Event) => void;
   _accessToken?: string;
+  _analytics?: Record<string, string>;
   _authConfig?: CortiAuth.AuthTokenDerivable;
   _region?: string;
   _tenantName?: string;
@@ -55,7 +56,6 @@ export abstract class SocketController<
   #connectingPromise: Promise<boolean | "superseded"> | null = null;
   #isConnecting = false;
 
-  protected abstract readonly _analytics: Record<string, string>;
   protected abstract _connectThroughProxy(
     config: TConfig,
     proxy: ProxyOptions,
@@ -81,7 +81,9 @@ export abstract class SocketController<
 
     return this._connectThroughProxy(
       config,
-      proxyWithAnalytics(proxyOptions, this._analytics),
+      this.host._analytics
+        ? proxyWithAnalytics(proxyOptions, this.host._analytics)
+        : proxyOptions,
     );
   }
 
@@ -100,7 +102,7 @@ export abstract class SocketController<
     };
 
     this.#cortiClient = new CortiClient({
-      analytics: this._analytics,
+      analytics: this.host._analytics,
       auth,
       environment: this.host._region,
       tenantName: this.host._tenantName,

--- a/core/src/utils/analytics.ts
+++ b/core/src/utils/analytics.ts
@@ -1,0 +1,26 @@
+import type { ProxyOptions } from "../types.js";
+
+export const X_CORTI_ANALYTICS = "x-corti-analytics";
+
+export function speechAnalytics(
+  webComponent: string,
+  webComponentVersion: string,
+): Record<string, string> {
+  return {
+    web_component: webComponent,
+    web_component_version: webComponentVersion,
+  };
+}
+
+export function proxyWithAnalytics(
+  proxy: ProxyOptions,
+  analytics: Record<string, string>,
+): ProxyOptions {
+  return {
+    ...proxy,
+    queryParameters: {
+      ...proxy.queryParameters,
+      [X_CORTI_ANALYTICS]: JSON.stringify(analytics),
+    },
+  };
+}

--- a/core/src/utils/analytics.ts
+++ b/core/src/utils/analytics.ts
@@ -2,13 +2,27 @@ import type { ProxyOptions } from "../types.js";
 
 export const X_CORTI_ANALYTICS = "x-corti-analytics";
 
+function lowercased(source?: Record<string, string>): Record<string, string> {
+  if (!source) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    result[key.toLowerCase()] = value.toLowerCase();
+  }
+
+  return result;
+}
+
 export function speechAnalytics(
   webComponent: string,
   webComponentVersion: string,
   extra?: Record<string, string>,
 ): Record<string, string> {
   return {
-    ...extra,
+    ...lowercased(extra),
     web_component: webComponent,
     web_component_version: webComponentVersion,
   };
@@ -16,13 +30,13 @@ export function speechAnalytics(
 
 export function proxyWithAnalytics(
   proxy: ProxyOptions,
-  analytics: Record<string, string>,
+  analytics?: Record<string, string>,
 ): ProxyOptions {
   return {
     ...proxy,
     queryParameters: {
       ...proxy.queryParameters,
-      [X_CORTI_ANALYTICS]: JSON.stringify(analytics),
+      [X_CORTI_ANALYTICS]: JSON.stringify(lowercased(analytics)),
     },
   };
 }

--- a/core/src/utils/analytics.ts
+++ b/core/src/utils/analytics.ts
@@ -5,8 +5,10 @@ export const X_CORTI_ANALYTICS = "x-corti-analytics";
 export function speechAnalytics(
   webComponent: string,
   webComponentVersion: string,
+  extra?: Record<string, string>,
 ): Record<string, string> {
   return {
+    ...extra,
     web_component: webComponent,
     web_component_version: webComponentVersion,
   };

--- a/core/src/utils/languages.ts
+++ b/core/src/utils/languages.ts
@@ -61,17 +61,9 @@ export function getLanguagesByRegion(region?: string): {
   return { defaultLanguage, languages };
 }
 
-type LanguageEndpoints = Record<
-  Corti.LanguagesListRequestEndpoint,
-  { enabled: boolean }
->;
-
-export function enabledLanguageCodes(
+/** Codes from GET /languages. The `endpoint` query already limits the map to enabled languages. */
+export function languageCodesFromList(
   languages: Corti.LanguagesListResponse["languages"],
-  endpoint: Corti.LanguagesListRequestEndpoint,
 ): Corti.TranscribeSupportedLanguage[] {
-  return Object.entries(languages as Record<string, LanguageEndpoints>)
-    .filter(([, value]) => value[endpoint].enabled)
-    .map(([code]) => code)
-    .sort();
+  return Object.keys(languages).sort();
 }

--- a/core/src/utils/languages.ts
+++ b/core/src/utils/languages.ts
@@ -60,3 +60,18 @@ export function getLanguagesByRegion(region?: string): {
 
   return { defaultLanguage, languages };
 }
+
+type LanguageEndpoints = Record<
+  Corti.LanguagesListRequestEndpoint,
+  { enabled: boolean }
+>;
+
+export function enabledLanguageCodes(
+  languages: Corti.LanguagesListResponse["languages"],
+  endpoint: Corti.LanguagesListRequestEndpoint,
+): Corti.TranscribeSupportedLanguage[] {
+  return Object.entries(languages as Record<string, LanguageEndpoints>)
+    .filter(([, value]) => value[endpoint].enabled)
+    .map(([code]) => code)
+    .sort();
+}

--- a/dictation/package.json
+++ b/dictation/package.json
@@ -40,7 +40,7 @@
     "healthcare"
   ],
   "dependencies": {
-    "@corti/sdk": "4.0.0",
+    "@corti/sdk": "5.0.0",
     "@lit/context": "^1.1.6",
     "lit": "^3.3.3"
   },

--- a/dictation/src/components/corti-dictation.ts
+++ b/dictation/src/components/corti-dictation.ts
@@ -101,6 +101,7 @@ export class CortiDictation extends CortiRoot<
         class=${classMap({ hidden: isHidden })}
         .accessToken=${this.accessToken}
         .authConfig=${this.authConfig}
+        .analytics=${this.analytics}
         .socketUrl=${this.socketUrl}
         .socketProxy=${this.socketProxy}
         .dictationConfig=${this._dictationConfig}

--- a/dictation/src/components/corti-dictation.ts
+++ b/dictation/src/components/corti-dictation.ts
@@ -7,6 +7,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { ref } from "lit/directives/ref.js";
 import { DEFAULT_DICTATION_CONFIG } from "../constants.js";
 import type { DictationRoot } from "../contexts/dictation-context.js";
+import { WEB_COMPONENT_VERSION } from "../version.js";
 import type { DictationRecordingButton } from "./dictation-recording-button.js";
 
 import "../contexts/dictation-context.js";
@@ -21,6 +22,13 @@ export class CortiDictation extends CortiRoot<
   // ─────────────────────────────────────────────────────────────────────────────
   // Properties
   // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Published package version. `0.0.0-dev` in local builds.
+   */
+  get version(): string {
+    return WEB_COMPONENT_VERSION;
+  }
 
   /**
    * Overrides any device selection and instead uses getDisplayMedia to stream system audio.

--- a/dictation/src/contexts/dictation-context.ts
+++ b/dictation/src/contexts/dictation-context.ts
@@ -23,6 +23,13 @@ export class DictationRoot extends RootContext {
   // Properties
   // ─────────────────────────────────────────────────────────────────────────────
 
+  /**
+   * Published package version. `0.0.0-dev` in local builds.
+   */
+  get version(): string {
+    return WEB_COMPONENT_VERSION;
+  }
+
   @provide({ context: dictationConfigContext })
   @property({ attribute: false, type: Object })
   dictationConfig?: Corti.TranscribeConfig;

--- a/dictation/src/contexts/dictation-context.ts
+++ b/dictation/src/contexts/dictation-context.ts
@@ -54,6 +54,14 @@ export class DictationRoot extends RootContext {
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
 
+    if (changedProperties.has("analytics")) {
+      this._analytics = speechAnalytics(
+        WEB_COMPONENT_NAME,
+        WEB_COMPONENT_VERSION,
+        this.analytics,
+      );
+    }
+
     if (!changedProperties.has("dictationConfig")) {
       return;
     }

--- a/dictation/src/contexts/dictation-context.ts
+++ b/dictation/src/contexts/dictation-context.ts
@@ -1,9 +1,12 @@
+import { analyticsContext } from "@core/contexts/mixins/analytics-context.js";
 import { RootContext } from "@core/contexts/root-context.js";
+import { speechAnalytics } from "@core/utils/analytics.js";
 import { safeCustomElement } from "@core/utils/custom-elements.js";
 import type { Corti } from "@corti/sdk";
 import { createContext, provide } from "@lit/context";
 import type { PropertyValues } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
+import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export const dictationConfigContext = createContext<
   Corti.TranscribeConfig | undefined
@@ -13,6 +16,9 @@ export const debugDisplayAudioContext = createContext<boolean | undefined>(
 );
 @safeCustomElement("dictation-root")
 export class DictationRoot extends RootContext {
+  @provide({ context: analyticsContext })
+  @state()
+  _analytics = speechAnalytics(WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION);
   // ─────────────────────────────────────────────────────────────────────────────
   // Properties
   // ─────────────────────────────────────────────────────────────────────────────

--- a/dictation/src/controllers/dictation-controller.ts
+++ b/dictation/src/controllers/dictation-controller.ts
@@ -1,13 +1,11 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { TranscribeMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
-import { speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
   CortiWebSocketProxyClient,
 } from "@corti/sdk";
-import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export type { TranscribeMessage } from "@core/socket-messages.js";
 
@@ -26,11 +24,6 @@ export class DictationController extends SocketController<
   Corti.TranscribeConfig,
   TranscribeSocket
 > {
-  protected readonly _analytics = speechAnalytics(
-    WEB_COMPONENT_NAME,
-    WEB_COMPONENT_VERSION,
-  );
-
   async stopRecording(): Promise<void> {
     await this.pause();
   }

--- a/dictation/src/controllers/dictation-controller.ts
+++ b/dictation/src/controllers/dictation-controller.ts
@@ -1,7 +1,7 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { TranscribeMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
-import { proxyWithAnalytics, speechAnalytics } from "@core/utils/analytics.js";
+import { speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
@@ -43,7 +43,7 @@ export class DictationController extends SocketController<
       // awaitConfiguration: false — CONFIG_* appears in network activity before the socket is configured server-side
       awaitConfiguration: false,
       configuration: dictationConfig,
-      proxy: proxyWithAnalytics(proxy, this._analytics),
+      proxy,
     });
   }
 

--- a/dictation/src/controllers/dictation-controller.ts
+++ b/dictation/src/controllers/dictation-controller.ts
@@ -1,11 +1,13 @@
 import { SocketController } from "@core/controllers/socket-controller.js";
 import type { TranscribeMessage } from "@core/socket-messages.js";
 import type { ProxyOptions } from "@core/types.js";
+import { proxyWithAnalytics, speechAnalytics } from "@core/utils/analytics.js";
 import {
   type Corti,
   type CortiClient,
   CortiWebSocketProxyClient,
 } from "@corti/sdk";
+import { WEB_COMPONENT_NAME, WEB_COMPONENT_VERSION } from "../version.js";
 
 export type { TranscribeMessage } from "@core/socket-messages.js";
 
@@ -24,6 +26,11 @@ export class DictationController extends SocketController<
   Corti.TranscribeConfig,
   TranscribeSocket
 > {
+  protected readonly _analytics = speechAnalytics(
+    WEB_COMPONENT_NAME,
+    WEB_COMPONENT_VERSION,
+  );
+
   async stopRecording(): Promise<void> {
     await this.pause();
   }
@@ -36,7 +43,7 @@ export class DictationController extends SocketController<
       // awaitConfiguration: false — CONFIG_* appears in network activity before the socket is configured server-side
       awaitConfiguration: false,
       configuration: dictationConfig,
-      proxy,
+      proxy: proxyWithAnalytics(proxy, this._analytics),
     });
   }
 

--- a/dictation/src/version.ts
+++ b/dictation/src/version.ts
@@ -1,0 +1,2 @@
+export const WEB_COMPONENT_NAME = "@corti/dictation-web";
+export const WEB_COMPONENT_VERSION = "0.0.0-dev";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook:build": "tsc -b core && tsc -p tsconfig.stories.json && pnpm run analyze && storybook build"
   },
   "devDependencies": {
-    "@corti/sdk": "4.0.0",
+    "@corti/sdk": "5.0.0",
     "@lit/context": "^1.1.6",
     "@biomejs/biome": "^2.3.6",
     "@custom-elements-manifest/analyzer": "^0.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.3.6
         version: 2.4.16
       '@corti/sdk':
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 5.0.0
+        version: 5.0.0
       '@custom-elements-manifest/analyzer':
         specifier: ^0.10.3
         version: 0.10.10
@@ -84,8 +84,8 @@ importers:
   ambient:
     dependencies:
       '@corti/sdk':
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 5.0.0
+        version: 5.0.0
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -96,8 +96,8 @@ importers:
   dictation:
     dependencies:
       '@corti/sdk':
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 5.0.0
+        version: 5.0.0
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -188,8 +188,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@corti/sdk@4.0.0':
-    resolution: {integrity: sha512-XE5wbaUAoYNBvXqu4LP/k51veuzkOvNW/cBgxi2WgERzYC01cc0rAULWjcPR4Uh0xXaNMQi/XAeknbWZch5tww==}
+  '@corti/sdk@5.0.0':
+    resolution: {integrity: sha512-RyLbQeQj812HKB8yv8gDQhl1m6Ns3zbH06SwQ8rlyDesUoZB/nqZ46CZMOB48lDEiMc7lQ/x9210x5SkEv+mcg==}
     engines: {node: '>=18.0.0'}
 
   '@custom-elements-manifest/analyzer@0.10.10':
@@ -3874,7 +3874,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
-  '@corti/sdk@4.0.0':
+  '@corti/sdk@5.0.0':
     dependencies:
       ws: 8.21.0
     transitivePeerDependencies:

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -6,11 +6,11 @@ import {
 } from "../core/src/utils/analytics.js";
 
 describe("speech analytics", () => {
-  it("merges extra keys and keeps web_component identity", () => {
+  it("merges extra keys, lowercases them, and keeps web_component identity", () => {
     expect(
       speechAnalytics("@corti/dictation-web", "1.2.3", {
+        Workflow: "Ambient-Scribe",
         web_component: "spoof",
-        workflow: "ambient-scribe",
       }),
     ).to.deep.equal({
       web_component: "@corti/dictation-web",
@@ -28,8 +28,11 @@ describe("speech analytics", () => {
 
     expect(proxy.url).to.equal("wss://proxy.example/stream");
     expect(proxy.queryParameters?.foo).to.equal("bar");
-    expect(proxy.queryParameters?.[X_CORTI_ANALYTICS]).to.equal(
-      JSON.stringify(analytics),
-    );
+    expect(
+      JSON.parse(proxy.queryParameters?.[X_CORTI_ANALYTICS] ?? "{}"),
+    ).to.deep.equal({
+      web_component: "@corti/ambient-web",
+      web_component_version: "1.2.3",
+    });
   });
 });

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import {
+  proxyWithAnalytics,
+  speechAnalytics,
+  X_CORTI_ANALYTICS,
+} from "../core/src/utils/analytics.js";
+
+describe("speech analytics", () => {
+  it("builds web_component keys for the SDK analytics payload", () => {
+    expect(speechAnalytics("@corti/dictation-web", "1.2.3")).to.deep.equal({
+      web_component: "@corti/dictation-web",
+      web_component_version: "1.2.3",
+    });
+  });
+
+  it("puts the payload on the proxy x-corti-analytics query parameter", () => {
+    const analytics = speechAnalytics("@corti/ambient-web", "1.2.3");
+    const proxy = proxyWithAnalytics(
+      { queryParameters: { foo: "bar" }, url: "wss://proxy.example/stream" },
+      analytics,
+    );
+
+    expect(proxy.url).to.equal("wss://proxy.example/stream");
+    expect(proxy.queryParameters?.foo).to.equal("bar");
+    expect(proxy.queryParameters?.[X_CORTI_ANALYTICS]).to.equal(
+      JSON.stringify(analytics),
+    );
+  });
+});

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -6,10 +6,16 @@ import {
 } from "../core/src/utils/analytics.js";
 
 describe("speech analytics", () => {
-  it("builds web_component keys for the SDK analytics payload", () => {
-    expect(speechAnalytics("@corti/dictation-web", "1.2.3")).to.deep.equal({
+  it("merges extra keys and keeps web_component identity", () => {
+    expect(
+      speechAnalytics("@corti/dictation-web", "1.2.3", {
+        web_component: "spoof",
+        workflow: "ambient-scribe",
+      }),
+    ).to.deep.equal({
       web_component: "@corti/dictation-web",
       web_component_version: "1.2.3",
+      workflow: "ambient-scribe",
     });
   });
 

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -1,21 +1,32 @@
 import { expect } from "@open-wc/testing";
-import { enabledLanguageCodes } from "../core/src/utils/languages.js";
+import { languageCodesFromList } from "../core/src/utils/languages.js";
 
-describe("enabledLanguageCodes", () => {
-  const payload = {
-    da: { streams: { enabled: true }, transcribe: { enabled: true } },
-    en: { streams: { enabled: true }, transcribe: { enabled: false } },
-    sv: { streams: { enabled: false }, transcribe: { enabled: true } },
-  };
-
-  it("keeps codes enabled for the requested endpoint", () => {
-    expect(enabledLanguageCodes(payload, "transcribe")).to.deep.equal([
-      "da",
-      "sv",
-    ]);
-    expect(enabledLanguageCodes(payload, "streams")).to.deep.equal([
-      "da",
-      "en",
-    ]);
+describe("languageCodesFromList", () => {
+  it("uses the map keys from GET /languages", () => {
+    expect(
+      languageCodesFromList({
+        bg: {
+          endpoints: {
+            streams: { enabled: true },
+            transcribe: { enabled: true },
+            transcripts: { enabled: false },
+          },
+        },
+        da: {
+          endpoints: {
+            streams: { enabled: true },
+            transcribe: { enabled: true },
+            transcripts: { enabled: true },
+          },
+        },
+        "en-x-noformat": {
+          endpoints: {
+            streams: { enabled: true },
+            transcribe: { enabled: true },
+            transcripts: { enabled: true },
+          },
+        },
+      }),
+    ).to.deep.equal(["bg", "da", "en-x-noformat"]);
   });
 });

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { enabledLanguageCodes } from "../core/src/utils/languages.js";
+
+describe("enabledLanguageCodes", () => {
+  const payload = {
+    da: { streams: { enabled: true }, transcribe: { enabled: true } },
+    en: { streams: { enabled: true }, transcribe: { enabled: false } },
+    sv: { streams: { enabled: false }, transcribe: { enabled: true } },
+  };
+
+  it("keeps codes enabled for the requested endpoint", () => {
+    expect(enabledLanguageCodes(payload, "transcribe")).to.deep.equal([
+      "da",
+      "sv",
+    ]);
+    expect(enabledLanguageCodes(payload, "streams")).to.deep.equal([
+      "da",
+      "en",
+    ]);
+  });
+});


### PR DESCRIPTION
Dictation and ambient take the tenant language list from `GET /languages/` when authenticated, and tag SDK 5 traffic as `@corti/dictation-web` / `@corti/ambient-web` on `x-corti-analytics`.

Resolves [DXG-1034](https://linear.app/corti/issue/DXG-1034)
Resolves [DXG-1410](https://linear.app/corti/issue/DXG-1410)

## Languages

- Authenticated: `transcribe` for dictation, `streams` for ambient
- Empty API list is kept; region list only on skip or failed GET
- Failed GET still applies region defaults and fires `error`
- Integrator `languages` is unchanged; Studio uses existing `languages-changed`

## Analytics

- SDK 5 uses one `x-corti-analytics` JSON bag, not the two headers in the ticket
- Package root owns `web_component` + version; sockets consume it via context
- CI stamps `version.ts` on publish (`0.0.0-dev` locally)
